### PR TITLE
fix and add tests for defined type maps

### DIFF
--- a/mapiter.go
+++ b/mapiter.go
@@ -38,7 +38,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			if r, ok := n.(*ast.RangeStmt); ok {
 
 				// Check if range value is a map
-				if _, ok := pass.TypesInfo.TypeOf(r.X).(*types.Map); ok {
+				if _, ok := pass.TypesInfo.TypeOf(r.X).Underlying().(*types.Map); ok {
 					pass.Reportf(r.TokPos, "iterating over a map")
 					return false
 				}

--- a/mapiter_test.go
+++ b/mapiter_test.go
@@ -10,6 +10,10 @@ func TestMapIter(t *testing.T) {
 	analysistest.Run(t, analysistest.TestData(), Analyzer, "basic")
 }
 
+func TestMapIterDefinedMap(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), Analyzer, "definedmap")
+}
+
 func TestMapIterTests(t *testing.T) {
 	analyzer := Analyzer
 	analyzer.Flags.Set("tests", "false")

--- a/testdata/src/basic/basic_test.go
+++ b/testdata/src/basic/basic_test.go
@@ -10,7 +10,7 @@ func TestBasic(t *testing.T) {
 
 	_, _ = basic(m)
 
-	// Iterating over a map is ignored in tests by default.
+	// Iterating over a map analysis is included in tests by default.
 	for k, v := range m { // want `iterating over a map`
 		_ = k
 		_ = v

--- a/testdata/src/definedmap/definedmap.go
+++ b/testdata/src/definedmap/definedmap.go
@@ -1,0 +1,26 @@
+package basic
+
+import "fmt"
+
+type kv struct {
+	k string
+	v bool
+}
+
+type mapStringBool map[string]bool
+
+func basic(m mapStringBool) (s []kv, err error) {
+
+	s = make([]kv, 0)
+
+	for k, v := range m { // want `iterating over a map`
+		kv := kv{k: k, v: v}
+		s = append(s, kv)
+	}
+
+	for i, v := range s { // no error
+		fmt.Printf("%d: %s", i, v.k)
+	}
+
+	return s, nil
+}

--- a/testdata/src/definedmap/definedmap_test.go
+++ b/testdata/src/definedmap/definedmap_test.go
@@ -1,0 +1,18 @@
+package basic
+
+import "testing"
+
+func TestBasic(t *testing.T) {
+
+	m := make(mapStringBool)
+	m["a"] = true
+	m["b"] = true
+
+	_, _ = basic(m)
+
+	// Iterating over a map analysis is included in tests by default.
+	for k, v := range m { // want `iterating over a map`
+		_ = k
+		_ = v
+	}
+}


### PR DESCRIPTION
The analysis was not detecting maps that have been declared with type definitions (search the _underlying_ keyword [here](https://golang.org/ref/spec#Type_declarations))